### PR TITLE
Take rolling-window approach for nucleus segmentation to scale with large image

### DIFF
--- a/S3segmenter.py
+++ b/S3segmenter.py
@@ -15,7 +15,7 @@ from skimage.filters import gaussian
 from skimage.feature import peak_local_max
 from skimage.color import label2rgb
 from skimage.io import imsave
-from skimage.segmentation import clear_border
+from skimage.segmentation import clear_border, watershed
 from scipy.ndimage.filters import uniform_filter
 from os.path import *
 from os import listdir, makedirs, remove
@@ -28,6 +28,9 @@ import sys
 import argparse
 import re
 import copy
+import datetime
+from joblib import Parallel, delayed
+from rowit import WindowView, crop_with_padding_mask
 
 
 def imshowpair(A,B):
@@ -54,64 +57,120 @@ def normI(I):
     J = J/(p99-p1);
     return J
 
+def contour_pm_watershed(
+    contour_pm, sigma=2, h=0, tissue_mask=None,
+    padding_mask=None, min_area=None, max_area=None
+):
+    if tissue_mask is None:
+        tissue_mask = np.ones_like(contour_pm)
+    padded = None
+    if padding_mask is not None and np.any(padding_mask == 0):
+        contour_pm, padded = crop_with_padding_mask(
+            contour_pm, padding_mask, return_mask=True
+        )
+        tissue_mask = crop_with_padding_mask(
+            tissue_mask, padding_mask
+        )
+    
+    maxima = peak_local_max(
+        extrema.h_maxima(
+            ndi.gaussian_filter(np.invert(contour_pm), sigma=sigma),
+            h=h
+        ),
+        indices=False,
+        footprint=np.ones((3, 3))
+    )
+    maxima = label(maxima).astype(np.int32)
+    
+    # Passing mask into the watershed function will exclude seeds outside
+    # of the mask, which gives fewer and more accurate segments
+    maxima = watershed(
+        contour_pm, maxima, watershed_line=True, mask=tissue_mask
+    ) > 0
+    
+    if min_area is not None and max_area is not None:
+        maxima = label(maxima, connectivity=1).astype(np.int32)
+        areas = np.bincount(maxima.ravel())
+        size_passed = np.arange(areas.size)[
+            np.logical_and(areas > min_area, areas < max_area)
+        ]
+        maxima *= np.isin(maxima, size_passed)
+        np.greater(maxima, 0, out=maxima)
+
+    if padded is None:
+        return maxima.astype(np.bool)
+    else:
+        padded[padded == 1] = maxima.flatten()
+        return padded.astype(np.bool)
+
 def S3NucleiSegmentationWatershed(nucleiPM,nucleiImage,logSigma,TMAmask,nucleiFilter,nucleiRegion):
     nucleiContours = nucleiPM[:,:,1]
     nucleiCenters = nucleiPM[:,:,0]
-    
-    del nucleiPM
     mask = resize(TMAmask,(nucleiImage.shape[0],nucleiImage.shape[1]),order = 0)>0
-    # nucleiContours = nucleiContours*mask
+ 
     if len(logSigma)==1:
          nucleiDiameter  = [logSigma*0.5, logSigma*1.5]
     else:
          nucleiDiameter = logSigma
     logMask = nucleiCenters > 150
-    gf=gaussian_filter(255-nucleiContours,logSigma[1]/30)
-    gf= extrema.h_maxima(gf,logSigma[1]/30)
-    fgm=peak_local_max(gf, indices=False,footprint=np.ones((3, 3)))
-    _, fgm= cv2.connectedComponents(fgm.astype(np.uint8))
-    allNuclei= morphology.watershed(nucleiContours,fgm,watershed_line=True, mask=mask)
-    del fgm
-    # allNuclei = ((foregroundMask)*mask)
-    # del foregroundMask
-    if nucleiFilter == 'IntPM':
-        P = regionprops(allNuclei,nucleiCenters,cache=False)
-    elif nucleiFilter == 'Int':
-        P = regionprops(allNuclei,nucleiImage,cache=False)
-    mean_int = np.array([prop.mean_intensity for prop in P]) 
-    #kmeans = KMeans(n_clusters=2).fit(mean_int.reshape(-1,1))
-    MITh = threshold_otsu(mean_int.reshape(-1,1))
-    allNuclei = np.zeros(mask.shape,dtype=np.uint32)
-    count = 0
-    del nucleiImage
     
-    for props in P:
-        intensity = props.mean_intensity
-        if intensity >MITh:
-            count += 1
-            yi = props.coords[:, 0]
-            xi = props.coords[:, 1]
-            allNuclei[yi, xi] = count
-    
-    P = regionprops(allNuclei,cache=False)
-    count=0
+    win_view_setting = WindowView(nucleiContours.shape, 2000, 500)
+
+    nucleiContours = win_view_setting.window_view_list(nucleiContours)
+    padding_mask = win_view_setting.padding_mask()
+    mask = win_view_setting.window_view_list(mask)
+
     maxArea = (logSigma[1]**2)*3/4
     minArea = (logSigma[0]**2)*3/4
-    nucleiMask = np.zeros(mask.shape,dtype=np.uint32)
-    for props in P:
-        area = props.area
-        solidity = props.solidity
-        if minArea < area < maxArea and solidity >0.8:
-            count += 1
-            yi = props.coords[:, 0]
-            xi = props.coords[:, 1]
-            nucleiMask[yi, xi] = count
-    return nucleiMask
-    
-#    img2 = nucleiImage.copy()
-#    stacked_img = np.stack((img2,)*3, axis=-1)
-#    stacked_img[X > 0] = [65535, 0, 0]
-#    imshowpair(img2,stacked_img)
+
+    foregroundMask = np.array(
+        Parallel(n_jobs=6)(delayed(contour_pm_watershed)(
+            img, sigma=logSigma[1]/30, h=logSigma[1]/30, tissue_mask=tm,
+            padding_mask=m, min_area=minArea, max_area=maxArea
+        ) for img, tm, m in zip(nucleiContours, mask, padding_mask))
+    )
+
+    del nucleiContours, mask
+
+    foregroundMask = win_view_setting.reconstruct(foregroundMask)
+    foregroundMask = label(foregroundMask, connectivity=1).astype(np.int32)
+
+    if nucleiFilter == 'IntPM':
+        int_img = nucleiCenters
+    elif nucleiFilter == 'Int':
+        int_img = nucleiImage
+
+    print('    ', datetime.datetime.now(), 'regionprops')
+    P = regionprops(foregroundMask, int_img)
+
+    def props_of_keys(prop, keys):
+        return [prop[k] for k in keys]
+
+    prop_keys = ['mean_intensity', 'area', 'solidity', 'label']
+    mean_ints, areas, solidities, labels = np.array(
+        Parallel(n_jobs=6)(delayed(props_of_keys)(prop, prop_keys) 
+            for prop in P
+        )
+    ).T
+    del P
+
+    MITh = threshold_otsu(mean_ints)
+
+    minSolidity = 0.8
+
+    passed = np.logical_and.reduce((
+        np.greater(mean_ints, MITh),
+        np.logical_and(areas > minArea, areas < maxArea),
+        np.greater(solidities, minSolidity)
+    ))
+
+    # set failed mask label to zero
+    foregroundMask *= np.isin(foregroundMask, labels[passed])
+
+    np.greater(foregroundMask, 0, out=foregroundMask)
+    foregroundMask = label(foregroundMask, connectivity=1).astype(np.int32)
+
+    return foregroundMask
 
 def bwmorph(mask,radius):
     mask = np.array(mask,dtype=np.uint8)
@@ -183,7 +242,7 @@ def exportMasks(mask,image,outputPath,filePrefix,fileName,saveFig=True,saveMasks
         kwargs['resolution'] = (resolution, resolution, 'cm')
         kwargs['metadata'] = None
         kwargs['description'] = '!!xml!!'
-        imsave(outputPath + os.path.sep + fileName + 'Mask.tif',mask, plugin="tifffile")
+        imsave(outputPath + os.path.sep + fileName + 'Mask.tif',mask, plugin="tifffile", check_contrast=False)
         
     if saveFig== True:
         mask=np.uint8(mask>0)

--- a/S3segmenter.py
+++ b/S3segmenter.py
@@ -60,7 +60,7 @@ def S3NucleiSegmentationWatershed(nucleiPM,nucleiImage,logSigma,TMAmask,nucleiFi
     
     del nucleiPM
     mask = resize(TMAmask,(nucleiImage.shape[0],nucleiImage.shape[1]),order = 0)>0
-    nucleiContours = nucleiContours*mask
+    # nucleiContours = nucleiContours*mask
     if len(logSigma)==1:
          nucleiDiameter  = [logSigma*0.5, logSigma*1.5]
     else:
@@ -70,10 +70,10 @@ def S3NucleiSegmentationWatershed(nucleiPM,nucleiImage,logSigma,TMAmask,nucleiFi
     gf= extrema.h_maxima(gf,logSigma[1]/30)
     fgm=peak_local_max(gf, indices=False,footprint=np.ones((3, 3)))
     _, fgm= cv2.connectedComponents(fgm.astype(np.uint8))
-    foregroundMask= morphology.watershed(nucleiContours,fgm,watershed_line=True)
+    allNuclei= morphology.watershed(nucleiContours,fgm,watershed_line=True, mask=mask)
     del fgm
-    allNuclei = ((foregroundMask)*mask)
-    del foregroundMask
+    # allNuclei = ((foregroundMask)*mask)
+    # del foregroundMask
     if nucleiFilter == 'IntPM':
         P = regionprops(allNuclei,nucleiCenters,cache=False)
     elif nucleiFilter == 'Int':

--- a/rowit.py
+++ b/rowit.py
@@ -1,0 +1,76 @@
+import numpy as np
+from skimage.util import view_as_windows, montage
+
+
+class WindowView(object):
+
+    def __init__(
+        self, img_shape, block_size, overlap_size
+    ):
+        self.img_shape = img_shape
+        self.block_size = block_size
+        self.overlap_size = overlap_size
+
+        self.step_size = block_size - overlap_size
+
+    def window_view_list(self, img, pad_mode='constant'):
+        half = int(self.overlap_size / 2)
+        img = np.pad(img, (
+            (half, self.padded_shape[0] - self.img_shape[0] - half), 
+            (half, self.padded_shape[1] - self.img_shape[1] - half),
+        ), mode=pad_mode)
+        
+        return self._window_view_list(img)
+    
+    def padding_mask(self):
+        half = int(self.overlap_size / 2)
+        padding_mask = np.ones(self.img_shape, dtype=np.bool)
+        padding_mask = np.pad(padding_mask, (
+            (half, self.padded_shape[0] - self.img_shape[0] - half), 
+            (half, self.padded_shape[1] - self.img_shape[1] - half),
+        ), mode='constant', constant_values=0)
+        return self._window_view_list(padding_mask)
+
+    def reconstruct(self, img_window_view_list):
+        grid_shape = self.window_view_shape[:2]
+
+        start = int(self.overlap_size / 2)
+        end = int(self.block_size - start)
+
+        img_window_view_list = img_window_view_list[..., start:end, start:end]
+
+        return montage(
+            img_window_view_list, grid_shape=grid_shape
+        )[:self.img_shape[0], :self.img_shape[1]]
+        
+    @property
+    def padded_shape(self):
+        padded_shape = np.array(self.img_shape) + self.overlap_size
+        n = np.ceil((padded_shape - self.block_size) / self.step_size)
+        padded_shape = (self.block_size + (n * self.step_size)).astype(np.int)
+        return tuple(padded_shape)
+
+    @property 
+    def window_view_shape(self):
+        return view_as_windows(
+            np.empty(self.padded_shape), 
+            self.block_size, self.step_size
+        ).shape
+
+    def _window_view_list(self, img):
+        return (
+            view_as_windows(img, self.block_size, self.step_size)
+                .reshape(-1, self.block_size, self.block_size)
+        )
+
+def crop_with_padding_mask(img, padding_mask, return_mask=False):
+    if np.all(padding_mask == 1):
+        return (img, padding_mask) if return_mask else img
+    (r_s, r_e), (c_s, c_e) = [
+        (i.min(), i.max() + 1)
+        for i in np.where(padding_mask == 1)
+    ]
+    padded = np.zeros_like(img)
+    img = img[r_s:r_e, c_s:c_e]
+    padded[r_s:r_e, c_s:c_e] = 1
+    return (img, padded) if return_mask else img


### PR DESCRIPTION
The current approach in this PR has a set value for the rolling-window size and overlap. Adding a user-selected window and overlap size can be further implemented in the future. The first commit is to match the v0.4.0 result with the requested output, in which the tissue mask is only used in the watershed function call. I'm open to the discussions on at which point the tissue mask should be applied, and can further modify the PR. 

In a test job of segmenting a 10000 by 10000 pixels image, it took the parallelization approach 200 seconds (6-cores) compared to 550 seconds without parallelization, and the peak RAM usage was 4.5 GB and 9.2 GB respectively. 