### PR TITLE
Fix downsizing mode selection by passing `is_mask` flag directly

### DIFF
--- a/S3segmenter.py
+++ b/S3segmenter.py
@@ -331,6 +331,7 @@ def exportMasks(mask,image,outputPath,filePrefix,fileName,commit,metadata_args,s
             mask,
             outputPath + os.path.sep + fileName + '.ome.tif',
             channel_names=fileName,
+            is_mask=True,
             **metadata_args
         )     
     if saveFig== True:
@@ -341,6 +342,7 @@ def exportMasks(mask,image,outputPath,filePrefix,fileName,commit,metadata_args,s
             stacked_img,
             previewPath + os.path.sep + fileName + 'Outlines.ome.tif',
             channel_names=[f'{fileName} outlines', 'Segmentation image'],
+            is_mask=False,
             **metadata_args
         )
         
@@ -583,6 +585,7 @@ if __name__ == '__main__':
                 stacked_img,
                 outputPathPuncta,
                 channel_names=['puncta outlines', 'image channel'],
+                is_mask=False,
                 **metadata
                 )     
             

--- a/save_tifffile_pyramid.py
+++ b/save_tifffile_pyramid.py
@@ -102,7 +102,7 @@ def save_pyramid(
     return
 
 def downsize_channel(img, is_mask):
-    if is_mask == True:
+    if is_mask:
         return img[::2, ::2]
     else:
         return skimage.transform.downscale_local_mean(img, (2, 2)).astype(img.dtype)

--- a/save_tifffile_pyramid.py
+++ b/save_tifffile_pyramid.py
@@ -20,7 +20,8 @@ def save_pyramid(
     pixel_sizes=(1, 1),
     pixel_size_units=('µm', 'µm'),
     channel_names=None,
-    software=None
+    software=None,
+    is_mask=False
 ):
     assert '.ome.tif' in str(output_path)
     assert len(pixel_sizes) == len(pixel_size_units) == 2
@@ -88,9 +89,9 @@ def save_pyramid(
         )
         for i in range(subifds):
             if i == 0:
-                down_2x_img = downsize_img_channels(out_img)
+                down_2x_img = downsize_img_channels(out_img, is_mask=is_mask)
             else:
-                down_2x_img = downsize_img_channels(down_2x_img)
+                down_2x_img = downsize_img_channels(down_2x_img, is_mask=is_mask)
             tiff_out.write(
                 data=down_2x_img,
                 subfiletype=1,
@@ -100,14 +101,14 @@ def save_pyramid(
     out_img = out_img.reshape(img_shape_ori)
     return
 
-def downsize_channel(img):
-    if np.all((img == img.min()) | (img == img.max())):
+def downsize_channel(img, is_mask):
+    if is_mask == True:
         return img[::2, ::2]
     else:
         return skimage.transform.downscale_local_mean(img, (2, 2)).astype(img.dtype)
 
-def downsize_img_channels(img):
+def downsize_img_channels(img, is_mask):
     return np.array([
-        downsize_channel(c)
+        downsize_channel(c, is_mask=is_mask)
         for c in img
     ])


### PR DESCRIPTION
Originally the `save_tifffile_pyramid.save_pyramid` function tries to guess whether a given image is a mask or an intensity image and select the downsize interpolation mode accordingly. The fix asks the user to specify whether a given image is an intensity image (the default) or a mask (passing `is_mask=True`). 