### PR TITLE
Updated ome_types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8.0
 
-RUN pip install numpy==1.22.3 scikit-learn scikit-image==0.16.2 matplotlib tifffile==2021.6.6 opencv-python==4.3.0.36 ome_types imagecodecs
+RUN pip install numpy==1.22.3 scikit-learn scikit-image==0.16.2 matplotlib tifffile==2021.6.6 opencv-python==4.3.0.36 ome_types==0.4.5 imagecodecs
 
 COPY S3segmenter.py ./app/S3segmenter.py
 COPY save_tifffile_pyramid.py ./app/save_tifffile_pyramid.py


### PR DESCRIPTION
A user reports in https://github.com/labsyspharm/mcmicro/issues/356#issuecomment-1880247398 that s3seg fails to parse XML metadata from their image, but that a manual call to `ome_types.from_xml()` succeeds without problems. This is most likely due to `s3seg` using an older version of `ome_types`. The PR bumps `ome_types` to the latest release version, which is currently 0.4.5.